### PR TITLE
thread instance memory fix

### DIFF
--- a/src/zlog.c
+++ b/src/zlog.c
@@ -71,6 +71,7 @@ static void zlog_clean_rest_thread(void)
 	a_thread = pthread_getspecific(zlog_thread_key);
 	if (!a_thread) return;
 	zlog_thread_del(a_thread);
+	pthread_setspecific(zlog_thread_key, NULL);
 	return;
 }
 


### PR DESCRIPTION
Fix memory errors when doing zlog_init/zlog_fini multiple times 
in the same process. This sets the thread instance data to NULL to
make sure that it gets recreated correctly.

This is useful in cases where multiple unit tests are 
performed in the same state if zlog is used in a python c module.
