### PR TITLE
Fix an uninitialized read. If the archive_path string has a plain '#r' i...

### DIFF
--- a/src/rotater.c
+++ b/src/rotater.c
@@ -359,7 +359,7 @@ static int zlog_rotater_roll_files(zlog_rotater_t * a_rotater)
 static int zlog_rotater_parse_archive_path(zlog_rotater_t * a_rotater)
 {
 	int nwrite;
-	int nread;
+	int nread = 0;
 	char *p;
 	size_t len;
 


### PR DESCRIPTION
Here's a fix for an unitialized crash that was causing crashes for me at runtime. I found & verified this with valgrind. Hopefully it's useful for you.
