### PR TITLE
Bugfix/osx set dynamiclib

### DIFF
--- a/doc/GettingStart-CN.txt
+++ b/doc/GettingStart-CN.txt
@@ -15,6 +15,7 @@ $ cd zlog-latest-stable/
 $ make 
 $ sudo make install
 or
+$ make PREFIX=/usr/local/
 $ sudo make PREFIX=/usr/local/ install
 
 PREFIX指明了安装的路径，安转完之后为了让你的程序能找到zlog动态库

--- a/doc/GettingStart-EN.txt
+++ b/doc/GettingStart-EN.txt
@@ -15,6 +15,7 @@ $ cd zlog-latest-stable/
 $ make 
 $ sudo make install
 or
+$ make PREFIX=/usr/local/
 $ sudo make PREFIX=/usr/local/ install
 
 PREFIX indicates the installation destination for zlog. After installation, refresh your dynamic linker to make sure your program can find zlog library.  

--- a/src/makefile
+++ b/src/makefile
@@ -46,6 +46,13 @@ DYLIB_MAKE_CMD=$(CC) -shared -Wl,-soname,$(DYLIB_MINOR_NAME) -o $(DYLIBNAME) $(L
 STLIBNAME=$(LIBNAME).$(STLIBSUFFIX)
 STLIB_MAKE_CMD=ar rcs $(STLIBNAME)
 
+# Installation related variables
+PREFIX?=/usr/local
+INCLUDE_PATH?=include
+LIBRARY_PATH?=lib
+INSTALL_INCLUDE_PATH= $(PREFIX)/$(INCLUDE_PATH)
+INSTALL_LIBRARY_PATH= $(PREFIX)/$(LIBRARY_PATH)
+
 # Platform-specific overrides
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 ifeq ($(uname_S),SunOS)
@@ -57,7 +64,7 @@ ifeq ($(uname_S),Darwin)
   DYLIBSUFFIX=dylib
   DYLIB_MINOR_NAME=$(LIBNAME).$(ZLOG_MAJOR).$(ZLOG_MINOR).$(DYLIBSUFFIX)
   DYLIB_MAJOR_NAME=$(LIBNAME).$(ZLOG_MAJOR).$(DYLIBSUFFIX)
-  DYLIB_MAKE_CMD=$(CC) -shared -Wl,-install_name,$(DYLIB_MINOR_NAME) -o $(DYLIBNAME) $(LDFLAGS)
+  DYLIB_MAKE_CMD=$(CC) -dynamiclib -install_name $(INSTALL_LIBRARY_PATH)/$(DYLIB_MINOR_NAME) -o $(DYLIBNAME) $(LDFLAGS)
 endif
 
 ifeq ($(uname_S),AIX)
@@ -145,13 +152,7 @@ clean:
 dep:
 	$(CC) -MM *.c
 
-# Installation related variables and target
-PREFIX?=/usr/local
-INCLUDE_PATH?=include
-LIBRARY_PATH?=lib
-INSTALL_INCLUDE_PATH= $(PREFIX)/$(INCLUDE_PATH)
-INSTALL_LIBRARY_PATH= $(PREFIX)/$(LIBRARY_PATH)
-
+# Installation target
 ifeq ($(uname_S),SunOS)
   INSTALL?= cp -r
 endif


### PR DESCRIPTION
Currently OSX cannot find the dynamic library if it is installed in a non-system directory without setting environment variables:

```
dyld: Library not loaded: libzlog.1.2.dylib
  Referenced from: /Users/basho/dev/clients/c/riak-c-client/./build/riak_c_client
  Reason: image not found
Trace/BPT trap: 5
```

 This change encodes the target path but requires the PREFIX to be set at build time since it is encoded in the dylib  as mentioned in the GettingStarted-X.txt files.
