### PR TITLE
Fix compiling on Buildroot

### DIFF
--- a/src/fmacros.h
+++ b/src/fmacros.h
@@ -14,7 +14,11 @@
 #define _XOPEN_SOURCE
 #endif
 
+#ifndef _LARGEFILE_SOURCE
 #define _LARGEFILE_SOURCE
+#endif
+#ifndef _FILE_OFFSET_BITS
 #define _FILE_OFFSET_BITS 64
+#endif
 
 #endif


### PR DESCRIPTION
Buildroot always specifies -D_LARGEFILE_SOURCE, -D_LARGEFILE64_SOURCE,
-D_FILE_OFFSET_BITS=64, so define them only, if they are not already
defined.

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>