### PR TITLE
compile: Remove -Werror and avoid build failures because of warnings

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -32,7 +32,7 @@ ZLOG_MINOR=2
 # Fallback to gcc when $CC is not in $PATH.
 CC:=$(shell sh -c 'type $(CC) >/dev/null 2>/dev/null && echo $(CC) || echo gcc')
 OPTIMIZATION?=-O2
-WARNINGS=-Wall -Werror -Wstrict-prototypes -fwrapv
+WARNINGS=-Wall -Wstrict-prototypes -fwrapv
 DEBUG?= -g -ggdb
 REAL_CFLAGS=$(OPTIMIZATION) -fPIC -pthread $(CFLAGS) $(WARNINGS) $(DEBUG)
 REAL_LDFLAGS=$(LDFLAGS) -pthread


### PR DESCRIPTION
Using -Werror on production is a bad idea, as otherwise harmless warnings
get treated as errors breaking builds. This is currently the case with
Nios-II architecture toolchain, warning about a deprecated macro:

../usr/nios2-buildroot-linux-gnu/sysroot/usr/include/features.h:148:3:
error: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Werror=cpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"

Instead of trying to fix the macro, let's fix the real issue here,
and remove -Werror.

Signed-off-by: Ezequiel Garcia ezequiel@vanguardiasur.com.ar
