### PR TITLE
Fix judgement since #r and #s must be exist once in archive path

### DIFF
--- a/src/rule.c
+++ b/src/rule.c
@@ -795,7 +795,7 @@ zlog_rule_t *zlog_rule_new(char *line,
 				}
 
 				p = strchr(a_rule->archive_path, '#');
-				if ( (p == NULL) || ((strchr(p, 'r') == NULL) || (strchr(p, 's') == NULL))) {
+				if ( (p == NULL) || ((strchr(p, 'r') == NULL) && (strchr(p, 's') == NULL))) {
 					zc_error("archive_path must contain #r or #s");
 					goto err;
 				}


### PR DESCRIPTION
As title. #74 fix breaks if the config file contains "#s" or "#r" in archive path