### PR TITLE
event.c: Cast pthread_t to unsigned long instead of unsigned int

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -82,7 +82,7 @@ zlog_event_t *zlog_event_new(int time_cache_count)
 	a_event->tid = pthread_self();
 
 	a_event->tid_str_len = sprintf(a_event->tid_str, "%lu", (unsigned long)a_event->tid);
-	a_event->tid_hex_str_len = sprintf(a_event->tid_hex_str, "0x%x", (unsigned int)a_event->tid);
+	a_event->tid_hex_str_len = sprintf(a_event->tid_hex_str, "0x%lu", (unsigned long)a_event->tid);
 
 	//zlog_event_profile(a_event, ZC_DEBUG);
 	return a_event;


### PR DESCRIPTION
On 64bit machines it ends up in errors

event.c:85:67: error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
  a_event->tid_hex_str_len = sprintf(a_event->tid_hex_str, "0x%x", (unsigned int)a_event->tid);

Signed-off-by: Khem Raj <raj.khem@gmail.com>