### PR TITLE
Add a multi-threads test and suppress some compilation warnings

### DIFF
--- a/test/makefile
+++ b/test/makefile
@@ -11,6 +11,7 @@ exe = 		\
 	test_level	\
 	test_leak	\
 	test_mdc	\
+	test_multithread	\
 	test_record	\
 	test_pipe	\
 	test_press_zlog		\

--- a/test/test_leak.c
+++ b/test/test_leak.c
@@ -33,15 +33,15 @@ int main(int argc, char** argv)
 		switch (i % 4) {
 		case 0:
 			rc = dzlog_init("test_leak.conf", "xxx");
-			dzlog_info("init");
+			dzlog_info("init, rc=[%d]", rc);
 			break;
 		case 1:
 			rc = zlog_reload(NULL);
-			dzlog_info("reload null");
+			dzlog_info("reload null, rc=[%d]", rc);
 			break;
 		case 2:
 			rc = zlog_reload("test_leak.2.conf");
-			dzlog_info("reload 2");
+			dzlog_info("reload 2, rc=[%d]", rc);
 			break;
 		case 3:
 			zlog_fini();

--- a/test/test_multithread.c
+++ b/test/test_multithread.c
@@ -1,0 +1,172 @@
+/*
+ * This file is part of the zlog Library.
+ *
+ * Copyright (C) 2017 by Philippe Corbes <philippe.corbes@gmail.com>
+ *
+ * Licensed under the LGPL v2.1, see the file COPYING in base directory.
+ *
+ * This test programm start NB_THREADS threads.
+ * Each thread loop and log an Info message every THREAD_LOOP_DELAY us (=10ms).
+ * The main loop check configuration file modification every seconds and reload configuration on file update.
+ * The main loop force reload configuration every RELOAD_DELAY " (=10").
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <signal.h>
+#include "zlog.h"
+
+#define CONFIG            "test_multithread.conf"
+#define NB_THREADS        200
+#define THREAD_LOOP_DELAY 10000	/* 0.01" */
+#define RELOAD_DELAY      10
+
+struct thread_info {    /* Used as argument to thread_start() */
+	pthread_t thread_id;    /* ID returned by pthread_create() */
+	int       thread_num;   /* Application-defined thread # */
+	zlog_category_t *zc;    /* The logger category struc address; (All threads will use the same category, so he same address) */
+	long long int loop;     /* Counter incremented to check the thread's health */
+};
+
+struct thread_info *tinfo;
+
+
+void intercept(int sig)
+{
+	int i;
+
+    printf("\nIntercept signal %d\n\n", sig);
+
+    signal (sig, SIG_DFL);
+    raise (sig);
+
+	printf("You can import datas below in a spreadsheat and check if any thread stopped increment the Loop counter during the test.\n\n");
+	printf("Thread;Loop\n");
+	for (i=0; i<NB_THREADS; i++)
+	{
+		printf("%d;%lld\n", tinfo[i].thread_num, tinfo[i].loop);
+    }
+
+    free(tinfo);
+
+    zlog_fini();
+}
+
+void *myThread(void *arg)
+{
+    struct thread_info *tinfo = arg;
+
+    tinfo->zc = zlog_get_category("thread");
+	if (!tinfo->zc) {
+		printf("get thread %d cat fail\n", tinfo->thread_num);
+	}
+	else
+	{
+		while(1)
+		{
+			usleep(THREAD_LOOP_DELAY);
+			zlog_info(tinfo->zc, "%d;%lld", tinfo->thread_num, tinfo->loop++);
+		}
+	}
+
+	return NULL;
+}
+
+int main(int argc, char** argv)
+{
+	int rc;
+	zlog_category_t *zc;
+	int i = 0;
+	struct stat stat_0, stat_1;
+
+	/* Create the logging directory if not yet ceated */
+	mkdir("./test_multithread-logs", 0777);
+
+	if (stat(CONFIG, &stat_0))
+	{
+		printf("Configuration file not found\n");
+		return -1;
+	}
+
+	rc = zlog_init(CONFIG);
+	if (rc) {
+		printf("main init failed\n");
+		return -2;
+	}
+
+	zc = zlog_get_category("main");
+	if (!zc) {
+		printf("main get cat fail\n");
+		zlog_fini();
+		return -3;
+	}
+
+	/* Interrupt (ANSI).		<Ctrl-C> */
+	if (signal(SIGINT, intercept) == SIG_IGN )
+	{
+		zlog_fatal(zc, "Can't caught the signal SIGINT, Interrupt (ANSI)");
+		signal(SIGINT, SIG_IGN );
+		return -4;
+	}
+
+	// start threads
+    tinfo = calloc(NB_THREADS, sizeof(struct thread_info));
+	for (i=0; i<NB_THREADS; i++)
+	{
+        tinfo[i].thread_num = i + 1;
+        tinfo[i].loop = 0;
+		if(pthread_create(&tinfo[i].thread_id, NULL, myThread, &tinfo[i]) != 0)
+		{
+			zlog_fatal(zc, "Unable to start thread %d", i);
+			zlog_fini();
+			return(-5);
+		}
+    }
+
+	/* Wait and log thread informations */
+	sleep(1);
+	for (i=0; i<NB_THREADS; i++)
+	{
+		zlog_info(zc, "Thread [%d], zlog_category:@%p", tinfo[i].thread_num, tinfo[i].zc);
+    }
+
+	/* Log main loop status */
+	i=0;
+	while(1)
+	{
+		int reload;
+
+		sleep(1);
+		i++;
+		zlog_info(zc, "Running time: %02d:%02d:%02d", i/3600, (i/60)%60, i%60);
+
+		/* Check configuration file update */
+		stat(CONFIG, &stat_1);
+
+		/* Is configuration file modified */
+		reload = (stat_0.st_mtime != stat_1.st_mtime);
+
+		/* Or do we want to reload periodicaly the configuration file */
+		if ( ! reload)
+			if ( RELOAD_DELAY > 0)
+				reload = (i % RELOAD_DELAY == 0);
+
+		if (reload)
+		{
+			zlog_info(zc, "Will reload configuration...");
+			rc = zlog_reload(CONFIG);
+			if (rc) {
+				printf("main init failed\n");
+				return -6;
+			}
+			zlog_info(zc, "Configuration reloaded :)");
+			stat(CONFIG, &stat_0);
+		}
+	}
+	
+    exit(EXIT_SUCCESS);
+}

--- a/test/test_multithread.conf
+++ b/test/test_multithread.conf
@@ -1,0 +1,7 @@
+[formats]
+simple = "%d.%ms - %-6c - %-5V - %F(%L)/%U() - %m%n"
+csv = "%d.%ms;%m%n"
+[rules]
+main.* >stdout; simple
+main.* "./test_multithread-logs.txt"; simple
+thread.* "./test_multithread-logs/threadslog.csv", 20KB * 30 ~ "./test_multithread-logs/threadslog#r.csv"; csv

--- a/test/test_press_write.c
+++ b/test/test_press_write.c
@@ -25,12 +25,12 @@ static long loop_count;
 void * work(void *ptr)
 {
 	long j = loop_count;
-	int rc;
-static char aa[] = "2012-06-14 20:30:38.481187 INFO   24536:140716226213632:test_press_zlog.c:36 loglog\n";
+    static char aa[] = "2012-06-14 20:30:38.481187 INFO   24536:140716226213632:test_press_zlog.c:36 loglog\n";
+
 	while(j-- > 0) {
 //		fprintf(fp, "2012-05-16 17:24:58.282603 INFO   22471:test_press_zlog.c:33 loglog\n");
 //		fwrite(aa, sizeof(aa)-1, 1, fp);
-		rc = write(fd, aa, sizeof(aa)-1);
+		write(fd, aa, sizeof(aa)-1);
 	}
 	return 0;
 }

--- a/test/test_press_write2.c
+++ b/test/test_press_write2.c
@@ -23,9 +23,9 @@ static long loop_count;
 void * work(void *ptr)
 {
 	long j = loop_count;
-	int rc;
-static char log[] = "2012-06-14 20:30:38.481187 INFO   24536:140716226213632:test_press_zlog.c:36 loglog\n";
+    static char log[] = "2012-06-14 20:30:38.481187 INFO   24536:140716226213632:test_press_zlog.c:36 loglog\n";
 	char file[20];
+
 	sprintf(file, "press.%ld.log", (long)ptr);
 
 	int fd;
@@ -33,7 +33,7 @@ static char log[] = "2012-06-14 20:30:38.481187 INFO   24536:140716226213632:tes
 	//FILE *fp;
 
 	while(j-- > 0) {
-		rc = write(fd, log, sizeof(log)-1);
+		write(fd, log, sizeof(log)-1);
 		//fwrite(log, sizeof(log)-1, 1, fp);
 	}
 	//fclose(fp);


### PR DESCRIPTION
I wrote the test/test_multithread program to check the "Multithread issue locks until log file rotation #93" issue. I don't confirm this issue. This program start threads  and reload periodicaly the configuration. The main loop is also able to detect a configuration file update and will reload the new configuration. To stop the test, simply hit Ctrl-C and chech statistics on screen.

The second commit solve some warnings on compilation