### PR TITLE
Added API to see if a given level is enabled

### DIFF
--- a/src/zlog.c
+++ b/src/zlog.c
@@ -1004,5 +1004,10 @@ int zlog_set_record(const char *rname, zlog_record_fn record_output)
 	}
 	return rc;
 }
+/*******************************************************************************/
+int zlog_level_enabled(zlog_category_t *category, const int level)
+{
+	return category && (zlog_category_needless_level(category, level) == 0);
+}
 
 const char *zlog_version(void) { return ZLOG_VERSION; }

--- a/src/zlog.h
+++ b/src/zlog.h
@@ -31,6 +31,7 @@ void zlog_fini(void);
 void zlog_profile(void);
 
 zlog_category_t *zlog_get_category(const char *cname);
+int zlog_level_enabled(zlog_category_t *category, const int level);
 
 int zlog_put_mdc(const char *key, const char *value);
 char *zlog_get_mdc(const char *key);
@@ -259,6 +260,14 @@ typedef enum {
 #define hdzlog_debug(buf, buf_len) \
 	hdzlog(__FILE__, sizeof(__FILE__)-1, __func__, sizeof(__func__)-1, __LINE__, \
 	ZLOG_LEVEL_DEBUG, buf, buf_len)
+
+/* enabled macros */
+#define zlog_fatal_enabled(zc) zlog_level_enabled(zc, ZLOG_LEVEL_FATAL)
+#define zlog_error_enabled(zc) zlog_level_enabled(zc, ZLOG_LEVEL_ERROR)
+#define zlog_warn_enabled(zc) zlog_level_enabled(zc, ZLOG_LEVEL_WARN)
+#define zlog_notice_enabled(zc) zlog_level_enabled(zc, ZLOG_LEVEL_NOTICE)
+#define zlog_info_enabled(zc) zlog_level_enabled(zc, ZLOG_LEVEL_INFO)
+#define zlog_debug_enabled(zc) zlog_level_enabled(zc, ZLOG_LEVEL_DEBUG)
 
 #ifdef __cplusplus
 }

--- a/test/makefile
+++ b/test/makefile
@@ -20,8 +20,9 @@ exe = 		\
 	test_press_write2	\
 	test_press_syslog	\
 	test_syslog	\
-	test_default \
-	test_profile
+	test_default	\
+	test_profile	\
+	test_enabled
 
 all     :       $(exe)
 

--- a/test/makefile
+++ b/test/makefile
@@ -22,9 +22,7 @@ exe = 		\
 	test_syslog	\
 	test_default	\
 	test_profile	\
-	test_default \
-	test_profile \
-	test_category \
+	test_category   \
 	test_enabled
 
 all     :       $(exe)

--- a/test/test_enabled.c
+++ b/test/test_enabled.c
@@ -1,0 +1,48 @@
+/*
+ * This file is part of the zlog Library.
+ *
+ * Copyright (C) 2018 by Teracom Telemática S/A
+ *
+ * Licensed under the LGPL v2.1, see the file COPYING in base directory.
+ */
+
+#include <stdio.h>
+#include "test_enabled.h"
+
+int main(int argc, char** argv)
+{
+	int rc;
+	zlog_category_t *zc;
+
+	rc = zlog_init("test_enabled.conf");
+	if (rc) {
+		printf("init failed\n");
+		return -1;
+	}
+
+	zc = zlog_get_category("my_cat");
+	if (!zc) {
+		printf("get cat fail\n");
+		zlog_fini();
+		return -2;
+	}
+
+	if (zlog_trace_enabled(zc)) {
+		/* do something heavy to collect data */
+		zlog_trace(zc, "hello, zlog - trace");
+	}
+
+	if (zlog_debug_enabled(zc)) {
+		/* do something heavy to collect data */
+		zlog_debug(zc, "hello, zlog - debug");
+	}
+
+	if (zlog_info_enabled(zc)) {
+		/* do something heavy to collect data */
+		zlog_info(zc, "hello, zlog - info");
+	}
+
+	zlog_fini();
+
+	return 0;
+}

--- a/test/test_enabled.conf
+++ b/test/test_enabled.conf
@@ -1,0 +1,6 @@
+[global]
+default format	=		"%V %v %m%n"
+[levels]
+TRACE = 30, LOG_DEBUG
+[rules]
+my_cat.TRACE		>stdout;

--- a/test/test_enabled.h
+++ b/test/test_enabled.h
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the zlog Library.
+ *
+ * Copyright (C) 2018 by Teracom Telemática S/A
+ *
+ * The zlog Library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The zlog Library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the zlog Library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __test_level_h
+#define __test_level_h
+
+#include "zlog.h"
+
+enum {
+	ZLOG_LEVEL_TRACE = 30,
+	/* must equals conf file setting */
+};
+
+#define zlog_trace(cat, format, args...) \
+	zlog(cat, __FILE__, sizeof(__FILE__)-1, __func__, sizeof(__func__)-1, __LINE__, \
+	ZLOG_LEVEL_TRACE, format, ##args)
+
+#define zlog_trace_enabled(cat) zlog_level_enabled(cat, ZLOG_LEVEL_TRACE)
+
+#endif


### PR DESCRIPTION
This commit adds an API to check if a given level is enabled before
build the message. Macros for default levels is also provided.

Sometimes the effort to build a complex/detailed log message can be very
costly, so it is useful in some applications to check if some level is
enabled in a category before take the decision to build the message.

Signed-off-by: Filipe Utzig <filipe.utzig@datacom.ind.br>