### PR TITLE
Add '-' to the list of accepted characters in category name

### DIFF
--- a/src/rule.c
+++ b/src/rule.c
@@ -635,12 +635,10 @@ zlog_rule_t *zlog_rule_new(char *line,
 		goto err;
 	}
 
-
 	/* check and set category */
 	for (p = category; *p != '\0'; p++) {
-		if ((!isalnum(*p)) && (*p != '_') && (*p != '*') && (*p != '!')) {
-			zc_error("category name[%s] character is not in [a-Z][0-9][_!*]",
-				 category);
+		if ((!isalnum(*p)) && (*p != '_') && (*p != '-') && (*p != '*') && (*p != '!')) {
+			zc_error("category name[%s] character is not in [a-Z][0-9][_!*-]", category);
 			goto err;
 		}
 	}

--- a/test/makefile
+++ b/test/makefile
@@ -21,7 +21,8 @@ exe = 		\
 	test_press_syslog	\
 	test_syslog	\
 	test_default \
-	test_profile
+	test_profile \
+	test_category
 
 all     :       $(exe)
 

--- a/test/test_category.c
+++ b/test/test_category.c
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the zlog Library.
+ *
+ * Copyright (C) 2011 by Hardy Simpson <HardySimpson1984@gmail.com>
+ *
+ * Licensed under the LGPL v2.1, see the file COPYING in base directory.
+ */
+
+#include <stdio.h>
+#include "zlog.h"
+
+int main(int argc, char** argv)
+{
+	int rc;
+	zlog_category_t *zc;
+
+	rc = zlog_init("./test_category.conf");
+	if (rc) {
+		printf("init failed\n");
+		return -1;
+	}
+
+	zc = zlog_get_category("my_cat");
+	if (!zc) {
+		printf("get cat fail\n");
+		zlog_fini();
+		return -2;
+	}
+
+	zlog_debug(zc, "hello, zlog - debug");
+
+	zc = zlog_get_category("my-cat");
+	if (!zc) {
+		printf("get cat fail\n");
+		zlog_fini();
+		return -2;
+	}
+
+	zlog_info(zc, "hello, zlog - info");
+
+	zlog_fini();
+	
+	return 0;
+}

--- a/test/test_category.conf
+++ b/test/test_category.conf
@@ -1,0 +1,5 @@
+[global]
+default format	=		"%V %v %m%n"
+[rules]
+my_cat.*		>stdout;
+my-cat.*		>stdout;


### PR DESCRIPTION
  Category names can contain '-' character also. New Tests to
  check correct category names are accepted.

Signed-off-by: Henrique Marks <henrique.marks@datacom.ind.br>