### PR TITLE
Add thread name if available through %T

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -78,7 +78,10 @@ zlog_event_t *zlog_event_new(int time_cache_count)
 		zc_error("gethostname fail, errno[%d]", errno);
 		goto err;
 	}
-
+	if (pthread_getname_np(a_event->tid, a_event->tid_str, sizeof(a_event->tid_str)) != 0)
+               a_event->tid_str_len = sprintf(a_event->tid_str, "%lu", (unsigned long)a_event->tid);
+       else
+               a_event->tid_str_len = strlen(a_event->tid_str);
 	a_event->host_name_len = strlen(a_event->host_name);
 
 	/* tid is bound to a_event

--- a/src/event.h
+++ b/src/event.h
@@ -59,7 +59,7 @@ typedef struct {
 	size_t pid_str_len;
 
 	pthread_t tid;
-	char tid_str[30 + 1];
+	char tid_str[56 + 1];
 	size_t tid_str_len;
 
 	char tid_hex_str[30 + 1];


### PR DESCRIPTION
In a multi-threaded environment, have the opportunity to have human-readable thread name in the log prefix.

- `%T` : is now replaced with the thread name if available, if not the current (tid) logic is used

Example:
```c
// caller side
pthread_create(&tid...);
pthread_setname_np(tid, "thread_name");
//Then the log can display "thread_name" if it is defined so in zlog.conf
```
