### PR TITLE
fix zlog_rule_del close invalid fd

### DIFF
--- a/src/rule.c
+++ b/src/rule.c
@@ -944,7 +944,7 @@ void zlog_rule_del(zlog_rule_t * a_rule)
 		zc_arraylist_del(a_rule->dynamic_specs);
 		a_rule->dynamic_specs = NULL;
 	}
-	if (a_rule->static_fd) {
+	if (a_rule->static_fd > 0) {
 		if (close(a_rule->static_fd)) {
 			zc_error("close fail, maybe cause by write, errno[%d]", errno);
 		}


### PR DESCRIPTION
a_rule->static_fd may be set to -1, https://github.com/HardySimpson/zlog/blob/ac1a4782b80bce7adb2d9197bd332a334eb2b530/src/rule.c#L829. 