### PR TITLE
docs: fix simple typo, ouput -> output

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ In the configuration file log messages in the category "my_cat" and a level of D
 -------------
  *  syslog model, better than log4j model
  *  log format customization
- *  multiple output destinations including static file path, dynamic file path, stdout, stderr, syslog, user-defined ouput
+ *  multiple output destinations including static file path, dynamic file path, stdout, stderr, syslog, user-defined output
  *  runtime manually or automatically refresh configure(safely)
  *  high-performance, 250'000 logs/second on my laptop, about 1000 times faster than syslog(3) with rsyslogd
  *  user-defined log level

--- a/src/level_list.h
+++ b/src/level_list.h
@@ -20,7 +20,7 @@ void zlog_level_list_profile(zc_arraylist_t *levels, int flag);
 /* if l is wrong or str=="", return -1 */
 int zlog_level_list_set(zc_arraylist_t *levels, char *line);
 
-/* spec ouput use, fast */
+/* spec output use, fast */
 /* rule output use, fast */
 /* if not found, return levels[254] */
 zlog_level_t *zlog_level_list_get(zc_arraylist_t *levels, int l);

--- a/src/rule.h
+++ b/src/rule.h
@@ -37,7 +37,7 @@ struct zlog_rule_s {
 	 * [!] log level != rule level
 	 */
 	int level;
-	unsigned char level_bitmap[32]; /* for category determine whether ouput or not */
+	unsigned char level_bitmap[32]; /* for category determine whether output or not */
 
 	unsigned int file_perms;
 	int file_open_flags;

--- a/src/zlog.c
+++ b/src/zlog.c
@@ -636,7 +636,7 @@ void vzlog(zlog_category_t * category,
 	 * but it is safe, the bitmap is valid as long as category exist,
 	 * And will be the right value after zlog_reload()
 	 *
-	 * For speed up, if one log will not be ouput,
+	 * For speed up, if one log will not be output,
 	 * There is no need to aquire rdlock.
 	 */
 	if (zlog_category_needless_level(category, level)) return;


### PR DESCRIPTION
There is a small typo in README.md, src/level_list.h, src/rule.h, src/zlog.c.

Should read `output` rather than `ouput`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md