### PR TITLE
Fix valgrind error

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -384,7 +384,7 @@ static int zlog_conf_parse_line(zlog_conf_t * a_conf, char *line, int *section)
 {
 	int nscan;
 	int nread;
-	char name[MAXLEN_CFG_LINE + 1];
+	char name[MAXLEN_CFG_LINE + 1] = "";
 	char word_1[MAXLEN_CFG_LINE + 1];
 	char word_2[MAXLEN_CFG_LINE + 1];
 	char word_3[MAXLEN_CFG_LINE + 1];


### PR DESCRIPTION
Simple fix to get rid of the valgrind error 'Conditional jump or move depends on uninitialised value'.