### PR TITLE
Fix #226 compiling issue for auto-tool fork

### DIFF
--- a/src/fmacros.h
+++ b/src/fmacros.h
@@ -10,7 +10,7 @@
 #ifndef _XOPEN_SOURCE_EXTENDED
 #define _XOPEN_SOURCE_EXTENDED
 #endif
-#else
+#elif !defined(__APPLE__)   // Enables 'phtread_threadid_np' in MacOSX SDKs
 #define _XOPEN_SOURCE
 #endif
 


### PR DESCRIPTION
Signed-off-by: Zhentao Huang <zhentao_huang@hotmail.com>

For [auto tool](https://github.com/bmanojlovic/zlog) fork

### Platform
* OS : MacOSX 12.6.1
* SDK : MacOSX 13.0
* autoconf : 2.71
* automake : 1.16.5
* compiler : apple clang 14.0.0

### Issue 
zlog is not able to pass compiling on MacOSX with SDK 13.0( either with 11.3 or 12.3)
```
../../src/event.c:97:5: error: implicit declaration of function 'pthread_threadid_np' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    pthread_threadid_np(NULL, &tid64);
```
### Root Cause
1. In MacOSX sdks `pthread/phtread.h` wrapped declaration of `pthread_thread_np` with a condition like this:
```
#if (!defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE)) || defined(_DARWIN_C_SOURCE) || defined(__cplusplus) // line 520, OSX sdk 13.0
...
int pthread_threadid_np(pthread_t _Nullable,__uint64_t* _Nullable);  // line 527, OSX sdk 13.0
#else
...
```

2. `fmacro.h` defined `_XOPEN_SOURCE` in line 14

These two prevents `pthread_threadid_np` being visible. So error occured.

### Fix 
To minimize effect the fix just bypasses `_XOPEN_SOURCE` declaration via macro `__APPLE__`