### PR TITLE
bug for rotating log file when archive_max_size is GB

### DIFF
--- a/src/rule.c
+++ b/src/rule.c
@@ -780,7 +780,7 @@ zlog_rule_t *zlog_rule_new(char *line,
 
 		if (file_limit) {
 			memset(archive_max_size, 0x00, sizeof(archive_max_size));
-			nscan = sscanf(file_limit, " %[0-9MmKkBb] * %d ~",
+			nscan = sscanf(file_limit, " %[0-9GgMmKkBb] * %d ~",
 					archive_max_size, &(a_rule->archive_max_count));
 			if (nscan) {
 				a_rule->archive_max_size = zc_parse_byte_size(archive_max_size);


### PR DESCRIPTION
when we set rotate-file-limit to `1GB`，however, the variable `archive_max_size` will be set to values `1`, this is a bug !!!

when we write ***1B*** data use `dzlog_info()`，***data length is equal to `archive_max_size`***, this may cause log file rotated, even though current log file size is much less than  rotate limit;

The configuration file is as follows:
```ini
[formats]
simple = "%m%n"
[rules]
*.*  "./test.log", 1GB * 0 ~ "./test.log.#s"; simple
```