### PR TITLE
Fix #237 rotate fail

### DIFF
--- a/src/lockfile.c
+++ b/src/lockfile.c
@@ -28,7 +28,7 @@ LOCK_FD lock_file(char* path)
 		zc_error("lock file error : %d ", err);
     }
 #else
-    LOCK_FD fd = open(path, O_RDWR | O_CREAT | O_EXCL, S_IRWXU | S_IRWXG | S_IRWXO);
+    LOCK_FD fd = open(path, O_RDWR | O_CREAT, S_IRWXU | S_IRWXG | S_IRWXO);
     if (fd == INVALID_LOCK_FD)
     {
 		zc_error("lock file error : %s ", strerror(errno));


### PR DESCRIPTION
Each time zlog rotates the logs, lock file will be opened. However, when the lock file already exists, this O_EXCL flag will cause the open command to return an error.