### PR TITLE
Fix %g spec cause zlog conf parse failed

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -552,7 +552,8 @@ zlog_spec_t *zlog_spec_new(char *pattern_start, char **pattern_next, int *time_c
 				p += 3;
 			} else {
 				nread = 0;
-				nscan = sscanf(p, "d(%[^)])%n", a_spec->time_fmt, &nread);
+				p++;
+				nscan = sscanf(p, "(%[^)])%n", a_spec->time_fmt, &nread);
 				if (nscan != 1) {
 					nread = 0;
 				}


### PR DESCRIPTION
can`t parse the documented spec ```%g(%F)``` which has params in ()
https://github.com/HardySimpson/zlog/commit/26263f96eb78e016e9b0b75797f9ec315c2e1897#r138249594