### PR TITLE
CVE-2024-22857: buffer overflow patched

### DIFF
--- a/src/rule.c
+++ b/src/rule.c
@@ -880,8 +880,10 @@ zlog_rule_t *zlog_rule_new(char *line,
 		}
 		break;
 	case '$' :
-		sscanf(file_path + 1, "%s", a_rule->record_name);
-			
+		// read only MAXLEN_PATH characters from the file_path + 1
+		strncpy(a_rule->record_name, file_path + 1, MAXLEN_PATH);
+		a_rule->record_name[MAXLEN_PATH] = '\0';
+		
 		if (file_limit) {  /* record path exists */
 			p = strchr(file_limit, '"');
 			if (!p) {


### PR DESCRIPTION
Size of `record_name` is **`MAXLEN_PATH(1024) + 1`** but `file_path` may have data upto **`MAXLEN_CFG_LINE(MAXLEN_PATH*4) + 1`**. So a check was missing in `zlog_rule_new()` while copying the `record_name` from `file_path + 1` which caused the buffer overflow. An attacker can exploit this vulnerability to overwrite the `zlog_record_fn record_func` function pointer to get arbitrary code execution.