### PR TITLE
fix "str is [], can't find level" error

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -567,7 +567,9 @@ static int zlog_conf_build_with_file(zlog_conf_t * a_conf)
 		}
 	}
 
-	a_conf->level = zlog_level_list_atoi(a_conf->levels, a_conf->log_level);
+	if (a_conf->log_level[0] != '\0') {
+		a_conf->level = zlog_level_list_atoi(a_conf->levels, a_conf->log_level);
+	}
 
 exit:
 	fclose(fp);


### PR DESCRIPTION
#159 引入 log_level 默认值，但是在未配置的情况下，默认值是`\0`，引发 `ERROR (1891873:level_list.c:141) str is [], can't find level` 错误。