### PR TITLE
 Fix zlog_env_conf concurrency question

### DIFF
--- a/src/zlog.c
+++ b/src/zlog.c
@@ -809,9 +809,9 @@ void vzlog(zlog_category_t * category,
 	 * For speed up, if one log will not be output,
 	 * There is no need to aquire rdlock.
 	 */
-	if (zlog_category_needless_level(category, level)) return;
-
 	pthread_rwlock_rdlock(&zlog_env_lock);
+	
+	if (zlog_category_needless_level(category, level)) return;
 
 	if (!zlog_env_is_init) {
 		zc_error("never call zlog_init() or dzlog_init() before");
@@ -856,9 +856,9 @@ void hzlog(zlog_category_t *category,
 {
 	zlog_thread_t *a_thread;
 
-	if (zlog_category_needless_level(category, level)) return;
-
 	pthread_rwlock_rdlock(&zlog_env_lock);
+	
+	if (zlog_category_needless_level(category, level)) return;
 
 	if (!zlog_env_is_init) {
 		zc_error("never call zlog_init() or dzlog_init() before");
@@ -904,9 +904,9 @@ void vdzlog(const char *file, size_t filelen,
 {
 	zlog_thread_t *a_thread;
 
-	if (zlog_category_needless_level(zlog_default_category, level)) return;
-
 	pthread_rwlock_rdlock(&zlog_env_lock);
+	
+	if (zlog_category_needless_level(zlog_default_category, level)) return;
 
 	if (!zlog_env_is_init) {
 		zc_error("never call zlog_init() or dzlog_init() before");
@@ -957,9 +957,9 @@ void hdzlog(const char *file, size_t filelen,
 {
 	zlog_thread_t *a_thread;
 
-	if (zlog_category_needless_level(zlog_default_category, level)) return;
-
 	pthread_rwlock_rdlock(&zlog_env_lock);
+	
+	if (zlog_category_needless_level(zlog_default_category, level)) return;
 
 	if (!zlog_env_is_init) {
 		zc_error("never call zlog_init() or dzlog_init() before");
@@ -1012,9 +1012,9 @@ void zlog(zlog_category_t * category,
 	zlog_thread_t *a_thread;
 	va_list args;
 
-	if (category && zlog_category_needless_level(category, level)) return;
-
 	pthread_rwlock_rdlock(&zlog_env_lock);
+	
+	if (category && zlog_category_needless_level(category, level)) return;
 
 	if (!zlog_env_is_init) {
 		zc_error("never call zlog_init() or dzlog_init() before");
@@ -1188,7 +1188,13 @@ int zlog_set_record(const char *rname, zlog_record_fn record_output)
 /*******************************************************************************/
 int zlog_level_enabled(zlog_category_t *category, const int level)
 {
-	return category && ((zlog_category_needless_level(category, level) == 0));
+	int enable = 0;
+
+	pthread_rwlock_rdlock(&zlog_env_lock);
+	enable = category && ((zlog_category_needless_level(category, level) == 0));
+	pthread_rwlock_unlock(&zlog_env_lock);
+	
+	return enable;
 }
 
 const char *zlog_version(void) { return ZLOG_VERSION; }

--- a/src/zlog.c
+++ b/src/zlog.c
@@ -811,7 +811,7 @@ void vzlog(zlog_category_t * category,
 	 */
 	pthread_rwlock_rdlock(&zlog_env_lock);
 	
-	if (zlog_category_needless_level(category, level)) return;
+	if (zlog_category_needless_level(category, level)) goto exit;
 
 	if (!zlog_env_is_init) {
 		zc_error("never call zlog_init() or dzlog_init() before");
@@ -858,7 +858,7 @@ void hzlog(zlog_category_t *category,
 
 	pthread_rwlock_rdlock(&zlog_env_lock);
 	
-	if (zlog_category_needless_level(category, level)) return;
+	if (zlog_category_needless_level(category, level)) goto exit;
 
 	if (!zlog_env_is_init) {
 		zc_error("never call zlog_init() or dzlog_init() before");
@@ -906,7 +906,7 @@ void vdzlog(const char *file, size_t filelen,
 
 	pthread_rwlock_rdlock(&zlog_env_lock);
 	
-	if (zlog_category_needless_level(zlog_default_category, level)) return;
+	if (zlog_category_needless_level(zlog_default_category, level)) goto exit;
 
 	if (!zlog_env_is_init) {
 		zc_error("never call zlog_init() or dzlog_init() before");
@@ -959,7 +959,7 @@ void hdzlog(const char *file, size_t filelen,
 
 	pthread_rwlock_rdlock(&zlog_env_lock);
 	
-	if (zlog_category_needless_level(zlog_default_category, level)) return;
+	if (zlog_category_needless_level(zlog_default_category, level)) goto exit;
 
 	if (!zlog_env_is_init) {
 		zc_error("never call zlog_init() or dzlog_init() before");
@@ -1014,7 +1014,7 @@ void zlog(zlog_category_t * category,
 
 	pthread_rwlock_rdlock(&zlog_env_lock);
 	
-	if (category && zlog_category_needless_level(category, level)) return;
+	if (category && zlog_category_needless_level(category, level)) goto exit;
 
 	if (!zlog_env_is_init) {
 		zc_error("never call zlog_init() or dzlog_init() before");


### PR DESCRIPTION
Log printing interfaces, such as `zlog` and `vzlog`, do not invoke `zlog_env_lock` to lock when accessing `zlog_env_conf`.

However, the `zlog_reload` interface deletes `zlog_env_conf` from the lock. As a result, a null pointer error occurs.