### PR TITLE
WIP: fix #276: double-free panic in gcc attribute destructor logging

### DIFF
--- a/src/zlog.c
+++ b/src/zlog.c
@@ -64,10 +64,18 @@ static void zlog_fini_inner(void)
 
 static void zlog_clean_rest_thread(void)
 {
+	int rc;
+
 	zlog_thread_t *a_thread;
 	a_thread = pthread_getspecific(zlog_thread_key);
 	if (!a_thread) return;
 	zlog_thread_del(a_thread);
+
+	rc = pthread_setspecific(zlog_thread_key, NULL);
+	if (rc) {
+		zc_error("pthread_setspecific fail, rc[%d]", rc);
+		return;
+	}
 	return;
 }
 


### PR DESCRIPTION
fix #276