### PR TITLE
conf: Return an error if zlog_init is called with a non-regular file

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -37,12 +37,6 @@
 #include "rotater.h"
 #include "zc_defs.h"
 
-#ifdef _WIN32
-#define STATS_FILE stat
-#else
-#define STATS_FILE lstat
-#endif
-
 /*******************************************************************************/
 #define ZLOG_CONF_DEFAULT_FORMAT "default = \"%D %V [%p:%F:%L] %m%n\""
 #define ZLOG_CONF_DEFAULT_RULE "*.*        >stdout"
@@ -471,11 +465,17 @@ static int zlog_conf_build_with_file(zlog_conf_t * a_conf)
 	int section = 0;
 	/* [global:1] [levels:2] [formats:3] [rules:4] */
 
-	if (STATS_FILE(a_conf->file, &a_stat)) {
+	if (stat(a_conf->file, &a_stat)) {
 		zc_error("lstat conf file[%s] fail, errno[%d]", a_conf->file,
 			 errno);
 		return -1;
 	}
+
+	if (!S_ISREG(a_stat.st_mode)) {
+		zc_error("conf file[%s] is not a regular file", a_conf->file);
+		return -1;
+	}
+
 	localtime_r(&(a_stat.st_mtime), &local_time);
 	strftime(a_conf->mtime, sizeof(a_conf->mtime), "%Y-%m-%d %H:%M:%S", &local_time);
 


### PR DESCRIPTION
Currently, calling zlog_init with a non-regular file (e.g., a directory) didn’t return an error. The logger would have been configured the same as with an empty file.

The file is now checked to ensure it is regular, and an error is returned if it is not.

Fixes #278.