### PR TITLE
Issue when compiling on some systems

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -98,7 +98,7 @@ zlog_event_t *zlog_event_new(int time_cache_count)
 	a_event->tid = pthread_self();
 
 	a_event->tid_str_len = sprintf(a_event->tid_str, "%lu", (unsigned long)a_event->tid);
-	a_event->tid_hex_str_len = sprintf(a_event->tid_hex_str, "%x", (unsigned int)a_event->tid);
+	a_event->tid_hex_str_len = sprintf(a_event->tid_hex_str, "%lx", (unsigned long)a_event->tid);
 
 #ifdef __linux__
 	a_event->ktid = syscall(SYS_gettid);


### PR DESCRIPTION
Hi,
when compiling zlog on some non-GNU systems, it looks like #133 or like
```
alpinevm:~/zlog_github# make
cd src && make all
make[1]: Entering directory '/root/zlog_github/src'
cc -std=c99 -pedantic -c -O2 -fPIC -pthread  -Wall -Werror -Wstrict-prototypes -fwrapv -g -ggdb event.c
event.c: In function 'zlog_event_new':
event.c:101:72: error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
  101 |         a_event->tid_hex_str_len = sprintf(a_event->tid_hex_str, "%x", (unsigned int)a_event->tid);
      |                                                                        ^
cc1: all warnings being treated as errors
make[1]: *** [Makefile:194: event.o] Error 1
make[1]: Leaving directory '/root/zlog_github/src'
make: *** [Makefile:6: all] Error 2
alpinevm:~/zlog_github# make  clean
cd src && make clean
make[1]: Entering directory '/root/zlog_github/src'
rm -rf libzlog.so libzlog.a zlog-chk-conf *.o *.gcda *.gcno *.gcov libzlog.so.1.2 libzlog.so.1
make[1]: Leaving directory '/root/zlog_github/src'
cd test && make clean
make[1]: Entering directory '/root/zlog_github/test'
rm -f press.log* *.o test_tmp test_longlog test_buf test_bitmap test_conf test_conf2 test_hashtable test_hello test_hex test_init test_level test_leak test_mdc test_multithread test_record test_pipe test_press_zlog test_press_zlog2 test_press_write test_press_write2 test_press_syslog test_syslog test_default test_profile test_category test_prompt test_enabled
make[1]: Leaving directory '/root/zlog_github/test'
cd doc && make clean
make[1]: Entering directory '/root/zlog_github/doc'
rm -f *.pdf *.haux *.html *.htoc *.tex *.lyx~
make[1]: Leaving directory '/root/zlog_github/doc'
rm -f TAGS
alpinevm:~/zlog_github# 

```
on alpine.

It's just about a wrong sprintf format control sequence, so I changed the cast to the correct data type and replaced the wrong format control sequence.
It's still working on Ubuntu and now also on alpine linux.

Regards,
Felix