### PR TITLE
event.c: include stdint header

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
+#include <stdint.h>
 
 #include <pthread.h>
 #include <unistd.h>


### PR DESCRIPTION
Both `buf.c` and `event.c` use the `uint64_t` type. However, only `buf.c` includes `<stdint.h>` to use this integer type, and that situation breaks some old (but compatible) compilers:

```
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_devel_zlog/zlog/work/zlog-1.2.18/src/event.c:106:13: error: expected ';' after expression
    uint64_t tid64;
            ^
            ;
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_devel_zlog/zlog/work/zlog-1.2.18/src/event.c:106/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_devel_zlog/zlog/work/zlog-1.2.18/src/event.c:106::13: error: expected ';' after expression5
    uint64_t tid64;
            ^
            ;
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_devel_zlog/zlog/work/zlog-1.2.18/src/event.c:106:5: error: use of undeclared identifier 'uint64_t'
    uint64_t tid64;
    ^
: error: use of undeclared identifier 'uint64_t'
    uint64_t tid64;
    ^
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_devel_zlog/zlog/work/zlog-1.2.18/src/event.c:106:14: error: use of undeclared identifier 'tid64'
    uint64_t tid64;
             ^
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_devel_zlog/zlog/work/zlog-1.2.18/src/event.c:106:14: error: use of undeclared identifier 'tid64'
    uint64_t tid64;
             ^
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_devel_zlog/zlog/work/zlog-1.2.18/src/event.c:107:32: error: use of undeclared identifier 'tid64'
    pthread_threadid_np(NULL, &tid64);
                               ^
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_devel_zlog/zlog/work/zlog-1.2.18/src/event.c:107:32: error: use of undeclared identifier 'tid64'
    pthread_threadid_np(NULL, &tid64);
                               ^
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_devel_zlog/zlog/work/zlog-1.2.18/src/event.c:108:31: error: use of undeclared identifier 'tid64'
    a_event->tid = (pthread_t)tid64;
                              ^
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_devel_zlog/zlog/work/zlog-1.2.18/src/event.c:108:31: error: use of undeclared identifier 'tid64'
    a_event->tid = (pthread_t)tid64;
                              ^
```