### PR TITLE
Use GNU variadic macros extension up to C++11 only

### DIFF
--- a/src/zlog.h
+++ b/src/zlog.h
@@ -112,7 +112,8 @@ typedef enum {
 # endif
 #endif
 
-#if defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L
+#if defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L || \
+    defined __cplusplus && __cplusplus >= 201103L
 /* zlog macros */
 #define zlog_fatal(cat, ...) \
 	zlog(cat, __FILE__, sizeof(__FILE__)-1, __func__, sizeof(__func__)-1, __LINE__, \


### PR DESCRIPTION
When compiling with the `-pedantic` option, a warning appears:
g++
```
zlog/src/zlog.h:157:37: warning: ISO C++ does not permit named variadic macros [-Wvariadic-macros]
  157 | #define zlog_fatal(cat, format, args...) \

```
clang:
```
zlog/src/zlog.h:156:37: warning: named variadic macros are a GNU extension [-Wvariadic-macros]
  156 | #define zlog_fatal(cat, format, args...) \
```

The problem was that for C++ the GNU extension is always used, but in [C++11 support was added](https://en.cppreference.com/w/cpp/preprocessor/replace)  anonymous variadic macros. 

