### PR TITLE
Add dzlog_level_enabled()

### DIFF
--- a/src/zlog.c
+++ b/src/zlog.c
@@ -1205,4 +1205,9 @@ int zlog_level_enabled(zlog_category_t *category, const int level)
 	return enable;
 }
 
+int dzlog_level_enabled(const int level)
+{
+	return zlog_level_enabled(zlog_default_category, level);
+}
+
 const char *zlog_version(void) { return ZLOG_VERSION; }

--- a/src/zlog.h
+++ b/src/zlog.h
@@ -68,6 +68,7 @@ void hzlog(zlog_category_t * category,
 
 int dzlog_init(const char *confpath, const char *cname);
 int dzlog_set_category(const char *cname);
+int dzlog_level_enabled(const int level);
 
 void dzlog(const char *file, size_t filelen,
 	const char *func, size_t funclen,


### PR DESCRIPTION
It would be great to have a simple way to determine if a certain log level is enabled for the default (dzlog) api!