### PR TITLE
Remove duplicate definition of zlog_level_enabled in zlog.h

### DIFF
--- a/src/zlog.h
+++ b/src/zlog.h
@@ -48,7 +48,6 @@ void zlog_remove_mdc(const char *key);
 void zlog_clean_mdc(void);
 
 int zlog_level_switch(zlog_category_t * category, int level);
-int zlog_level_enabled(zlog_category_t * category, int level);
 
 void zlog(zlog_category_t * category,
 	const char *file, size_t filelen,


### PR DESCRIPTION
The `zlog.h` file contains a redundant declaration of the method `zlog_level_enabled` which results in following compilation warning:
```
zlog.h:51:5: warning: redundant redeclaration of ‘zlog_level_enabled’ [-Wredundant-decls]
   51 | int zlog_level_enabled(zlog_category_t * category, int level);
      |     ^~~~~~~~~~~~~~~~~~
zlog.h:43:5: note: previous declaration of ‘zlog_level_enabled’ with type ‘int(zlog_category_t *, const int)’ {aka ‘int(struct zlog_category_s *, const int)’}
   43 | int zlog_level_enabled(zlog_category_t *category, const int level);
      |     ^~~~~~~~~~~~~~~~~~
```

Here is my suggestion to remove the duplicate definition to fix the compilation warning. No idea if there is a reason for this though, since it's been there for more than 5 years, so feel free to comment.